### PR TITLE
Upgrade NPM packages, use Browserify directly

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,16 +1,17 @@
 var gulp       = require('gulp'),
-    browserify = require('gulp-browserify');
+    browserify = require('browserify');
 
 gulp.task('scripts', function () {
 
-    gulp.src(['app/main.js'])
-        .pipe(browserify({
-            debug: true,
-            transform: [ 'reactify' ]
-        }))
+    var bundler = browserify({
+        entries: ['app/main.js'],
+        debug: true,
+        transform: [ 'reactify' ]
+    });
+
+    bundler.bundle()
         .pipe(gulp.dest('./public/'));
 
 });
 
 gulp.task('default', ['scripts']);
-

--- a/package.json
+++ b/package.json
@@ -2,21 +2,20 @@
   "name": "node-authentication",
   "main": "server.js",
   "dependencies": {
-    "body-parser": "~1.0.0",
-    "cookie-parser": "~1.0.0",
-    "ejs": "~0.8.5",
-    "express": "~4.0.0",
-    "griddle-react": "^0.1.19",
-    "path": "*",
-    "react": "~0.12.0"
+    "body-parser": "^1.14.1",
+    "cookie-parser": "^1.4.0",
+    "ejs": "^2.3.4",
+    "express": "^4.13.3",
+    "griddle-react": "^0.3.0",
+    "react": "^0.14.3",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "browserify": "~3.20.0",
-    "gulp": "~3.8.9",
-    "gulp-browserify": "~0.5.0",
-    "gulp-concat": "~2.4.1",
-    "node-jsx": "~0.2.0",
-    "react-tools": "^0.12.0",
-    "reactify": "0.15.2"
+    "browserify": "^12.0.1",
+    "gulp": "^3.9.0",
+    "gulp-concat": "^2.6.0",
+    "node-jsx": "^0.13.3",
+    "react-tools": "^0.13.3",
+    "reactify": "^1.1.1"
   }
 }


### PR DESCRIPTION
- Removes `gulp-browserify`.
- Tested on Node v0.10, v4.0, v5.0

Hi there! I was having trouble checking this out due to some old dependencies (`browserify` depending on `esprima-six`, which no longer exists, specifically). So I upgraded them! `gulp-browserify` is abandoned, so I just used `browserify.bundle()` directly.

The output is rendering, but I can't compare it to the previous version so I'll defer to you on whether or not it's correct. :) Thanks for the example!
