### PR TITLE
update browserify to latest to get rid of dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react": "~0.12.0"
   },
   "devDependencies": {
-    "browserify": "~3.20.0",
+    "browserify": "^14.5.0",
     "gulp": "~3.8.9",
     "gulp-browserify": "~0.5.0",
     "gulp-concat": "~2.4.1",


### PR DESCRIPTION
This allows `npm install` to run cleanly without a dependency error.